### PR TITLE
attr-bans with img-req-dimensions

### DIFF
--- a/lib/rules/attr-bans.js
+++ b/lib/rules/attr-bans.js
@@ -12,13 +12,17 @@ module.exports.lint = function (element, opts) {
         return [];
     }
 
+    var ignoreImgWidthAndHeight = opts['img-req-dimensions'];
+
     var issues = [];
 
     var attrs = element.attribs;
     bannedAttrs.forEach(function (name) {
         if (attrs.hasOwnProperty(name)) {
-            issues.push(new Issue('E001',
-                attrs[name].nameLineCol, { attribute: name }));
+            if (!(element.name === 'img' && ignoreImgWidthAndHeight && (name === 'width' || name === 'height'))) {
+                issues.push(new Issue('E001',
+                    attrs[name].nameLineCol, { attribute: name }));
+            }
         }
     });
 

--- a/test/functional/attr-bans.js
+++ b/test/functional/attr-bans.js
@@ -19,5 +19,35 @@ module.exports = [
         input: '<body banned></body>',
         opts: { 'attr-bans': ['banned'] },
         output: 1
+    }, {
+        desc: 'should match width if img-req-dimensions is false',
+        input: '<img width>',
+        opts: { 'attr-bans': ['width'], 'img-req-dimensions': false },
+        output: 1
+    }, {
+        desc: 'should not match width if img-req-dimensions is true',
+        input: '<img width>',
+        opts: { 'attr-bans': ['width'], 'img-req-dimensions': true },
+        output: 0
+    }, {
+        desc: 'should match height if img-req-dimensions is false',
+        input: '<img width height>',
+        opts: { 'attr-bans': ['height'], 'img-req-dimensions': false },
+        output: 1
+    }, {
+        desc: 'should not match height if img-req-dimensions is true',
+        input: '<img width height>',
+        opts: { 'attr-bans': ['height'], 'img-req-dimensions': true },
+        output: 0
+    }, {
+        desc: 'should match width if img-req-dimensions is true and the tag is not an img',
+        input: '<button width></button>',
+        opts: { 'attr-bans': ['width'], 'img-req-dimensions': true },
+        output: 1
+    }, {
+        desc: 'should match height if img-req-dimensions is true and the tag is not an img',
+        input: '<button width height></button>',
+        opts: { 'attr-bans': ['height'], 'img-req-dimensions': true },
+        output: 1
     }
 ];


### PR DESCRIPTION
if img-req-dimensions is set to true, attribute bans on width and
height are ignored if they belong to an img tag
